### PR TITLE
adding exceptions for non-present routes, request body syntax error, …

### DIFF
--- a/book-service/src/main/java/com/trilogyed/bookservice/controller/ControllerExceptionHandler.java
+++ b/book-service/src/main/java/com/trilogyed/bookservice/controller/ControllerExceptionHandler.java
@@ -5,8 +5,10 @@ import com.trilogyed.bookservice.exception.NotFoundException;
 import org.springframework.hateoas.VndErrors;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -55,6 +57,34 @@ public class ControllerExceptionHandler {
     @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
     public ResponseEntity<VndErrors> invalidFormat(InvalidFormatException e, WebRequest request){
         VndErrors error= new VndErrors(request.toString(),e.getMessage());
+        ResponseEntity<VndErrors> responseEntity = new ResponseEntity<>(error,HttpStatus.UNPROCESSABLE_ENTITY);
+        return responseEntity;
+    }
+
+    @ExceptionHandler(value = {HttpRequestMethodNotSupportedException.class})
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+    public ResponseEntity<VndErrors> invalidFormat(HttpRequestMethodNotSupportedException e, WebRequest request){
+        String msg = "This route is not supported. Please refer to the API documentation for valid routes";
+        VndErrors error= new VndErrors(request.toString(), msg);
+        ResponseEntity<VndErrors> responseEntity = new ResponseEntity<>(error,HttpStatus.UNPROCESSABLE_ENTITY);
+        return responseEntity;
+    }
+
+    @ExceptionHandler(value = {HttpMessageNotReadableException.class})
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+    public ResponseEntity<VndErrors> invalidFormat(HttpMessageNotReadableException e, WebRequest request){
+        String msg =  "The request body could not be read. Make sure all properties are present and all syntax is " +
+                "correct";
+        VndErrors error= new VndErrors(request.toString(), msg);
+        ResponseEntity<VndErrors> responseEntity = new ResponseEntity<>(error,HttpStatus.UNPROCESSABLE_ENTITY);
+        return responseEntity;
+    }
+
+    @ExceptionHandler(value = {NumberFormatException.class})
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+    public ResponseEntity<VndErrors> invalidFormat(NumberFormatException e, WebRequest request){
+        String msg =  "The route path parameter was expected to be an integer. Please correct and try again.";
+        VndErrors error= new VndErrors(request.toString(), msg);
         ResponseEntity<VndErrors> responseEntity = new ResponseEntity<>(error,HttpStatus.UNPROCESSABLE_ENTITY);
         return responseEntity;
     }

--- a/note-queue-consumer/src/main/resources/bootstrap.properties
+++ b/note-queue-consumer/src/main/resources/bootstrap.properties
@@ -1,2 +1,2 @@
-spring.application.name=note-queue-consumer
-spring.cloud.config.uri=http://localhost:9100
+#spring.application.name=note-queue-consumer
+#spring.cloud.config.uri=http://localhost:9100


### PR DESCRIPTION
…and when expecting ints but given string

NumberFormatException: for when the path parameter is expecting an int but there is a string instead
HttpMessageNotReadableException: for when there are syntax errors in the request body
HttpRequestMethodNotSupportedException: for when trying to send to an api route that does not exist